### PR TITLE
Fixes to the thin_by_cell_time function

### DIFF
--- a/R/thin_by_cell_time.R
+++ b/R/thin_by_cell_time.R
@@ -10,7 +10,8 @@
 #' @param data An [`sf::sf`] data frame, or a data frame with coordinate variables.
 #' These can be defined in `coords`, unless they have standard names
 #' (see details below).
-#' @param raster A [`terra::SpatRaster`] object that defined the grid
+#' @param raster A [`terra::SpatRaster`] object that defines the grid. The object must have 
+#' [`terra::time`] set as POSIXt for all layers.
 #' @param coords a vector of length two giving the names of the "x" and "y"
 #' coordinates, as found in `data`. If left to NULL, the function will
 #' try to guess the columns based on standard names `c("x", "y")`, `c("X","Y")`,
@@ -33,7 +34,7 @@ thin_by_cell_time <- function(data, raster, coords=NULL, time_col="time",
   # there should be no pattern
   data <- data[sample(1:nrow(data)),]
   # create a vector of times formatted as proper dates
-  time_lub <- data[,time_col] %>% as.data.frame() %>% dplyr::select(dplyr::all_of(time_col))
+  time_lub <- data %>% dplyr::select(dplyr::all_of(time_col))
   time_lub <- lubridate_fun(time_lub[,time_col])
   if (!inherits(time_lub,"POSIXct")){
     stop("time is not a date (or cannot be coerced to one)")
@@ -43,15 +44,15 @@ thin_by_cell_time <- function(data, raster, coords=NULL, time_col="time",
   if ( terra::timeInfo(raster)[1,2]=="years"){
     time_steps <- lubridate::date_decimal(time_steps)
   }
-  # convert time_lub dates into indeces for the SpatRasterDatset
-  time_indeces <-
+  # convert time_lub dates into indices for the SpatRasterDataset
+  time_indices <-
     sapply(time_lub, function(a, b) {
       which.min(abs(a - b))
     }, time_steps)
   data_thin<-NULL
-  for (i_index in unique(time_indeces)){
+  for (i_index in unique(time_indices)){
     # get data for this time_index, we remove coordinates as we don't need them
-    data_sub <- data %>% dplyr::filter(time_indeces==i_index)
+    data_sub <- data %>% dplyr::filter(time_indices==i_index)
     raster_sub <- raster[[1]][[i_index]]
     data_sub <- thin_by_cell(data_sub, raster_sub,
                              drop_na = drop_na, agg_fact=agg_fact)

--- a/man/thin_by_cell_time.Rd
+++ b/man/thin_by_cell_time.Rd
@@ -19,7 +19,8 @@ thin_by_cell_time(
 These can be defined in \code{coords}, unless they have standard names
 (see details below).}
 
-\item{raster}{A \code{\link[terra:SpatRaster-class]{terra::SpatRaster}} object that defined the grid}
+\item{raster}{A \code{\link[terra:SpatRaster-class]{terra::SpatRaster}} object that defines the grid. The object must have
+\code{\link[terra:time]{terra::time}} set as POSIXt for all layers.}
 
 \item{coords}{a vector of length two giving the names of the "x" and "y"
 coordinates, as found in \code{data}. If left to NULL, the function will


### PR DESCRIPTION
I have added two fixes to the thin_by_cell_time function.

First, the step where the data was subsetted by time_col in base R and then in tidyverse style threw errors because the base R subsetting removed the name of the selected column, which then made it impossible to subset using `dplyr::select`. I fixed this by changing it to subset tidyverse-style only.

Second, the documentation on the function was insufficient and caused confusion. The code requires the input SpatRaster to have time set as POSIXt for all layers or the time_indices step throws an error. I have added to the documentation to make it clear that terra::time must be used to set SpatRaster layers to POSIXt.