### PR TITLE
changes to choose_metric

### DIFF
--- a/R/add_member.R
+++ b/R/add_member.R
@@ -31,10 +31,7 @@ add_member.default <- function(x, member, ...) {
 add_member.tune_results <- function(x, member, metric = NULL, id = NULL, ...) {
   # set the metric if the simple ensemble is empty (and thus has no metric)
   if (is.null(attr(x, "best_metric"))) {
-    attr(x, "best_metric") <- utils::getFromNamespace(
-      "choose_metric",
-      "tune"
-    )(metric, member)
+    attr(x, "best_metric") <- tidydsm_choose_metric(metric, member)
   }
 
   # if metric is NULL
@@ -93,4 +90,18 @@ add_member.workflow_set <- function(x, member, metric = NULL, ...) {
     x <- x %>% add_member(this_res, metric = metric, id = i_wflow)
   }
   x
+}
+
+
+tidydsm_choose_metric <- function (metric, x) {
+  if (is.null(metric)) {
+    metric_vals <- .get_tune_metric_names(x)
+    metric <- metric_vals[1]
+    if (length(metric_vals) > 1) {
+      msg <- paste0("No value of `metric` was given; metric '",
+                    metric, "' ", "will be used.")
+      rlang::warn(msg)
+    }
+  }
+  metric
 }

--- a/R/add_member.R
+++ b/R/add_member.R
@@ -95,7 +95,7 @@ add_member.workflow_set <- function(x, member, metric = NULL, ...) {
 
 tidydsm_choose_metric <- function (metric, x) {
   if (is.null(metric)) {
-    metric_vals <- .get_tune_metric_names(x)
+    metric_vals <- tune::.get_tune_metric_names(x)
     metric <- metric_vals[1]
     if (length(metric_vals) > 1) {
       msg <- paste0("No value of `metric` was given; metric '",


### PR DESCRIPTION
We have a new version of tune coming out soon and reverse dependency checks flagged an issue for tidydsm. The package used: 

```r
if (is.null(attr(x, "best_metric"))) {
    attr(x, "best_metric") <- (utils::getFromNamespace("choose_metric",  "tune"))(metric, member)
  }
```

`choose_metric()` was not exported but will be in the next version but with a different argument signature. 

In this PR, I've copied the old function in s so you can use that if you like (renamed). 

We'll release tune in about 2-3 weeks. If you want to submit tidydsm prior to tune, this PR will help. If not, you could wait to get flagged by CRAN and use the new version of `choose_metrics()`. 