### PR TITLE
don't test invalid recipes behavior

### DIFF
--- a/tests/testthat/test_recipe_sf.R
+++ b/tests/testthat/test_recipe_sf.R
@@ -34,9 +34,6 @@ test_that("sdm_recipe_sf", {
   # work if we pass an sf object
   lacerta_rec_prep <- prep(lacerta_rec, training = lacerta_thin)
   expect_true(recipes::fully_trained(lacerta_rec_prep))
-  #  pass a dataframe without X and Y (it's fine as we add dummy X and Y)
-  lacerta_rec_prep <- prep(lacerta_rec, training = lacerta_thin %>% sf::st_drop_geometry())
-  expect_true(recipes::fully_trained(lacerta_rec_prep))
 
   ## now bake
   expect_true(all(c("X", "Y") %in% names(bake(lacerta_rec_prep, new_data = lacerta_thin))))


### PR DESCRIPTION
Hello @dramanica 👋 

I'm wrapping up a {recipes} release and this package popped up in the revdepcheck.

This version of {recipes} finally adds input checking to `prep()` such that it complains if the data used to specify the recipe, is in the same format as the data used to `prep()` it. https://github.com/tidymodels/recipes/pull/1330

 It is such that I request that you delete the following test as it isn't valid due to the newer checking mechanic. I'm planning to sent in {recipes} by July 1st. If you are able to merge and send to CRAN beforehand that would be awesome, thank you!