### PR TITLE
New vignette colour mess plot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,7 +69,8 @@ Suggests:
     testthat (>= 3.0.0),
     tidyterra,
     vdiffr,
-    xgboost
+    xgboost, 
+    ggpattern
 VignetteBuilder: knitr
 Config/testthat/edition: 3
 LazyData: true

--- a/vignettes/a0_tidysdm_overview.Rmd
+++ b/vignettes/a0_tidysdm_overview.Rmd
@@ -797,11 +797,20 @@ lacerta_mess_future_subset[lacerta_mess_future_subset < 0] <- 1
 # convert into polygon
 lacerta_mess_future_subset <- as.polygons(lacerta_mess_future_subset)
 
+library(ggpattern)
+
 # plot as a mask 
 ggplot() + geom_spatraster(data = prediction_future) + 
-  scale_fill_viridis_b(na.value = "transparent") + 
-  geom_sf(data = lacerta_mess_future_subset, 
-          fill= "lightgray", alpha = 0.5, linewidth = 0.5)
+  scale_fill_terrain_c() + 
+  geom_sf_pattern(data = lacerta_mess_future_subset, 
+          pattern = "stripe",
+          fill = "transparent",
+          pattern_fill= "black", 
+          pattern_density = 0.02,
+          pattern_spacing = 0.05,
+          pattern_angle = 45,
+          alpha = 0.1, 
+          linewidth = 0.5)
 
 ```
 


### PR DESCRIPTION
The plot overlaying the results from the MESS analyses and the habitat suitability results was hard to interpret due to the chosen colour palette. Therefore, changed to the same colour palette used for the habitat suitability plot and overlayed on it a patterned transparent mask ( using `ggpattern` ) to highlight the extrapolation areas.  
The package  `ggpattern` was added as a suggested package in the DESCRIPTION file. 