### PR TITLE
deal with conflicting column names in this_by_cell()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidysdm
 Title: Species Distribution Models with Tidymodels
-Version: 1.0.4.9001
+Version: 1.0.4.9002
 Authors@R: c(
     person("Michela", "Leonardi", role = "aut"),
     person("Margherita", "Colucci", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# `tidysdm` dev
+* resolve conflicting coords names in `thin_by_cell()`
+
 # `tidysdm` 1.0.4
 * improve documentation of `calib_class_threshold` and implement 
   `collect_calib_thresh`

--- a/R/thin_by_cell.R
+++ b/R/thin_by_cell.R
@@ -37,7 +37,9 @@ thin_by_cell <- function(data, raster, coords = NULL, drop_na = TRUE,
       "use `thin_by_cell_time()`"
     )
   }
-  if (inherits(raster, "stars")) raster <- as(raster, "SpatRaster")
+  if (inherits(raster, "stars")) {
+    raster <- as(raster, "SpatRaster")
+  }
   # add type checks for these parameters
   return_sf <- FALSE # flag whether we need to return an sf object
   if (inherits(data, "sf")) {
@@ -63,9 +65,19 @@ thin_by_cell <- function(data, raster, coords = NULL, drop_na = TRUE,
     } else {
       data <- data %>% dplyr::bind_cols(sf::st_coordinates(data))
     }
+    if (!is.null(coords) && !all(c("X", "Y") %in% coords)) {
+      warning(
+        "The 'coords' argument is ignored when 'data' is an sf object, ",
+        "as the coordinates are taken from the geometry."
+      )
+    }
+    coords <- c("X", "Y") # if we have an sf object, we take the coordinates
+    # from the geometry, so we know they are in the correct projection
     return_sf <- TRUE
+  } else {
+    coords <- check_coords_names(data, coords)
   }
-  coords <- check_coords_names(data, coords)
+
   # randomise the row order, so that when we get the first instance in a cell,
   # there should be no pattern
   data <- data[sample(seq_len(nrow(data))), ]

--- a/tests/testthat/test_thin_by_cell.R
+++ b/tests/testthat/test_thin_by_cell.R
@@ -65,6 +65,8 @@ test_that("thin_by_cell works correctly with coords and sf", {
   new_obs_xy <- thin_by_cell(occ, r, coords = c("X", "Y"))
   expect_equal(new_obs, new_obs_xy)
   names(occ) <- c("id", "X", "Y", "geometry")
+  # again we expect no error and no warning, and the same result as before
   set.seed(123)
   new_obs_xy_rep <- thin_by_cell(occ, r, coords = c("X", "Y"))
+  expect_equal(new_obs, new_obs_xy_rep)
 })

--- a/tests/testthat/test_thin_by_cell.R
+++ b/tests/testthat/test_thin_by_cell.R
@@ -68,5 +68,5 @@ test_that("thin_by_cell works correctly with coords and sf", {
   # again we expect no error and no warning, and the same result as before
   set.seed(123)
   new_obs_xy_rep <- thin_by_cell(occ, r, coords = c("X", "Y"))
-  expect_equal(new_obs, new_obs_xy_rep)
+  expect_equal(new_obs$id, new_obs_xy_rep$id)
 })

--- a/tests/testthat/test_thin_by_cell.R
+++ b/tests/testthat/test_thin_by_cell.R
@@ -27,3 +27,40 @@ test_that("thin_by_cell respects projections", {
   lacerta_thin_df <- thin_by_cell(lacerta_df, land_mask)
   expect_false(nrow(lacerta_thin_df) == nrow(lacerta_thin))
 })
+
+
+test_that("thin_by_cell works correctly with coords and sf", {
+  library(terra)
+  # Minimal raster grid
+  r <- terra::rast(ncols = 2, nrows = 2, xmin = 0, xmax = 2, ymin = 0, ymax = 2,
+            crs = "EPSG:4326")
+  values(r) <- 1
+
+  # sf points that ALSO keep longitude/latitude columns
+  occ <- tibble::tibble(
+    id = 1:3,
+    longitude = c(0.25, 0.75, 1.25),
+    latitude  = c(0.25, 0.75, 1.25)
+  ) |>
+    sf::st_as_sf(coords = c("longitude", "latitude"), crs = 4326, remove = FALSE)
+
+  # this should work
+  set.seed(123)
+  new_obs <- thin_by_cell(occ, r)
+  # if we give coords, it should be ignored and we should get a warning
+  set.seed(123)
+  expect_warning(
+    new_obs_coords <- thin_by_cell(occ, r, coords = c("longitude",
+      "latitude"
+    )),
+    "The 'coords' argument is ignored when 'data' is an sf object, as")
+  expect_equal(new_obs, new_obs_coords)
+  # no warning with X and Y as coords
+  set.seed(123)
+  new_obs_XY <- thin_by_cell(occ, r, coords = c("X", "Y"))
+  expect_equal(new_obs, new_obs_XY)
+  names(occ)<- c("id", "X", "Y", "geometry")
+  set.seed(123)
+  new_obs_XY_rep <- thin_by_cell(occ, r, coords = c("X", "Y"))
+
+})

--- a/tests/testthat/test_thin_by_cell.R
+++ b/tests/testthat/test_thin_by_cell.R
@@ -32,17 +32,20 @@ test_that("thin_by_cell respects projections", {
 test_that("thin_by_cell works correctly with coords and sf", {
   library(terra)
   # Minimal raster grid
-  r <- terra::rast(ncols = 2, nrows = 2, xmin = 0, xmax = 2, ymin = 0, ymax = 2,
-            crs = "EPSG:4326")
+  r <- terra::rast(
+    ncols = 2, nrows = 2, xmin = 0, xmax = 2, ymin = 0, ymax = 2,
+    crs = "EPSG:4326"
+  )
   values(r) <- 1
 
   # sf points that ALSO keep longitude/latitude columns
   occ <- tibble::tibble(
     id = 1:3,
     longitude = c(0.25, 0.75, 1.25),
-    latitude  = c(0.25, 0.75, 1.25)
+    latitude = c(0.25, 0.75, 1.25)
   ) |>
-    sf::st_as_sf(coords = c("longitude", "latitude"), crs = 4326, remove = FALSE)
+    sf::st_as_sf(coords = c("longitude", "latitude"), crs = 4326,
+                 remove = FALSE)
 
   # this should work
   set.seed(123)
@@ -50,17 +53,18 @@ test_that("thin_by_cell works correctly with coords and sf", {
   # if we give coords, it should be ignored and we should get a warning
   set.seed(123)
   expect_warning(
-    new_obs_coords <- thin_by_cell(occ, r, coords = c("longitude",
+    new_obs_coords <- thin_by_cell(occ, r, coords = c(
+      "longitude",
       "latitude"
     )),
-    "The 'coords' argument is ignored when 'data' is an sf object, as")
+    "The 'coords' argument is ignored when 'data' is an sf object, as"
+  )
   expect_equal(new_obs, new_obs_coords)
   # no warning with X and Y as coords
   set.seed(123)
-  new_obs_XY <- thin_by_cell(occ, r, coords = c("X", "Y"))
-  expect_equal(new_obs, new_obs_XY)
-  names(occ)<- c("id", "X", "Y", "geometry")
+  new_obs_xy <- thin_by_cell(occ, r, coords = c("X", "Y"))
+  expect_equal(new_obs, new_obs_xy)
+  names(occ) <- c("id", "X", "Y", "geometry")
   set.seed(123)
-  new_obs_XY_rep <- thin_by_cell(occ, r, coords = c("X", "Y"))
-
+  new_obs_xy_rep <- thin_by_cell(occ, r, coords = c("X", "Y"))
 })


### PR DESCRIPTION
fix #100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of spatial coordinate arguments; users now receive a warning when the `coords` parameter is ignored for geometry-based spatial objects.
  * Enhanced coordinate validation logic for non-spatial data objects.

* **Tests**
  * Added test cases to validate coordinate argument behavior and warning messages with spatial data objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->